### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/aidm_server/blueprints/players.py
+++ b/aidm_server/blueprints/players.py
@@ -37,7 +37,8 @@ def add_player(campaign_id):
         }), 201
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": "Failed to create player", "details": str(e)}), 400
+        app.logger.error(f"Failed to create player: {str(e)}")
+        return jsonify({"error": "Failed to create player"}), 400
 
 def get_players(campaign_id):
     players = Player.query.filter_by(campaign_id=campaign_id).all()


### PR DESCRIPTION
Potential fix for [https://github.com/dreichner21/AIDM/security/code-scanning/3](https://github.com/dreichner21/AIDM/security/code-scanning/3)

To fix the problem, we should avoid sending the exception message back to the client. Instead, we can log the detailed error message on the server and return a generic error message to the client. This ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the `add_player` function to log the exception message instead of including it in the response.
- Return a generic error message to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
